### PR TITLE
Use correct require statement in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ gem install packageurl-ruby
 ## Usage
 
 ```ruby
-require 'packageurl-ruby'
+require 'package_url'
 
 purl = PackageURL.parse("pkg:gem/rails@6.1.4")
 purl.type # "gem"


### PR DESCRIPTION
While the gem is named `packageurl-ruby`, the module is named `package_url` and this is the name that must be used when invoking `require`.

```
$ gem install packageurl-ruby
Successfully installed packageurl-ruby-0.1.0
Parsing documentation for packageurl-ruby-0.1.0
Done installing documentation for packageurl-ruby after 0 seconds
1 gem installed
$ irb
irb(main):001:0> require 'packageurl-ruby'
Traceback (most recent call last):
        6: from /Users/bwilliams/.asdf/installs/ruby/2.7.5/bin/irb:23:in `<main>'
        5: from /Users/bwilliams/.asdf/installs/ruby/2.7.5/bin/irb:23:in `load'
        4: from /Users/bwilliams/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
        3: from (irb):1
        2: from /Users/bwilliams/.asdf/installs/ruby/2.7.5/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'
        1: from /Users/bwilliams/.asdf/installs/ruby/2.7.5/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'
LoadError (cannot load such file -- packageurl-ruby)
irb(main):002:0> require 'package_url'
=> true
```